### PR TITLE
Rails now returns the models embedded with associations

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -5,13 +5,13 @@ module Api
 
       def show
         organization = Organization.find(params[:id])
+        toInclude = [:mailing_address, :practice_location_address, :other_provider_identifiers,
+            :taxonomy_licenses, :taxonomy_groups ]
         respond_to do |format|
           format.xml { render xml: organization, 
-            :include => [:mailing_address, :practice_location_address, :other_provider_identifiers,
-            :taxonomy_licenses, :taxonomy_groups ]}
+            :include => toInclude}
           format.json { render json: organization, 
-            :include => [:mailing_address, :practice_location_address, :other_provider_identifiers,
-            :taxonomy_licenses, :taxonomy_groups ]}
+            :include => toInclude}
         end
       end
 

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -5,13 +5,13 @@ module Api
 
       def show
         organization = Organization.find(params[:id])
-        toInclude = [:mailing_address, :practice_location_address, :other_provider_identifiers,
+        to_include = [:mailing_address, :practice_location_address, :other_provider_identifiers,
             :taxonomy_licenses, :taxonomy_groups ]
         respond_to do |format|
           format.xml { render xml: organization, 
-            :include => toInclude}
+            :include => to_include}
           format.json { render json: organization, 
-            :include => toInclude}
+            :include => to_include}
         end
       end
 

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -6,8 +6,12 @@ module Api
       def show
         organization = Organization.find(params[:id])
         respond_to do |format|
-          format.xml { render xml: organization }
-          format.json { render json: organization }
+          format.xml { render xml: organization, 
+            :include => [:mailing_address, :practice_location_address, :other_provider_identifiers,
+            :taxonomy_licenses, :taxonomy_groups ]}
+          format.json { render json: organization, 
+            :include => [:mailing_address, :practice_location_address, :other_provider_identifiers,
+            :taxonomy_licenses, :taxonomy_groups ]}
         end
       end
 

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -5,13 +5,13 @@ module Api
 
       def show
         provider = Provider.find(params[:id])
+        toInclude = [:mailing_address, :practice_location_address, :other_provider_identifiers,
+            :taxonomy_licenses, :taxonomy_groups ]
         respond_to do |format|
           format.xml { render xml: provider, 
-            :include => [:mailing_address, :practice_location_address, :other_provider_identifiers,
-            :taxonomy_licenses, :taxonomy_groups ]}
+            :include => toInclude}
           format.json { render json: provider, 
-            :include => [:mailing_address, :practice_location_address, :other_provider_identifiers,
-            :taxonomy_licenses, :taxonomy_groups ]}
+            :include => toInclude}
         end
       end
 

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -6,8 +6,12 @@ module Api
       def show
         provider = Provider.find(params[:id])
         respond_to do |format|
-          format.xml { render xml: provider }
-          format.json { render json: provider }
+          format.xml { render xml: provider, 
+            :include => [:mailing_address, :practice_location_address, :other_provider_identifiers,
+            :taxonomy_licenses, :taxonomy_groups ]}
+          format.json { render json: provider, 
+            :include => [:mailing_address, :practice_location_address, :other_provider_identifiers,
+            :taxonomy_licenses, :taxonomy_groups ]}
         end
       end
 

--- a/app/controllers/api/v1/providers_controller.rb
+++ b/app/controllers/api/v1/providers_controller.rb
@@ -5,13 +5,13 @@ module Api
 
       def show
         provider = Provider.find(params[:id])
-        toInclude = [:mailing_address, :practice_location_address, :other_provider_identifiers,
+        to_include = [:mailing_address, :practice_location_address, :other_provider_identifiers,
             :taxonomy_licenses, :taxonomy_groups ]
         respond_to do |format|
           format.xml { render xml: provider, 
-            :include => toInclude}
+            :include => to_include}
           format.json { render json: provider, 
-            :include => toInclude}
+            :include => to_include}
         end
       end
 


### PR DESCRIPTION
Added embedded models.  Currently using include, which requires each embedded model included to be specified.  There may be an automatic method to include all models automatically.