### PR TITLE
Speed up search index creation by correctly utilizing DB indexes

### DIFF
--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -55,6 +55,7 @@ namespace :medirectory do
                                                                                                    COALESCE(taxonomy_codes.specialization, ''))
                                                                              FROM taxonomy_licenses, taxonomy_codes
                                                                              WHERE providers.npi = taxonomy_licenses.entity_id
+                                                                             AND taxonomy_licenses.entity_type = 'Provider'
                                                                              AND taxonomy_licenses.code = taxonomy_codes.code),
                                                                        ' ')")
     puts "Updated taxonomy search for #{count} records"
@@ -94,6 +95,7 @@ namespace :medirectory do
                                                                                                        COALESCE(taxonomy_codes.specialization, ''))
                                                                                  FROM taxonomy_licenses, taxonomy_codes
                                                                                  WHERE organizations.npi = taxonomy_licenses.entity_id
+                                                                                 AND taxonomy_licenses.entity_type = 'Organization'
                                                                                  AND taxonomy_licenses.code = taxonomy_codes.code),
                                                                            ' ')")
     puts "Updated taxonomy search for #{count} records"


### PR DESCRIPTION
When a Postgres index uses two columns, the column specified first in the index must be explicitly referenced in the query for the index to be used at all. For some reason, Rails creates the index for polymorphic tables using the type column first. By including the type column, we speed up the search index creation... a lot.